### PR TITLE
Revise WebSocket communication & include the game state's type as a property

### DIFF
--- a/src/core/classic/Classic.ts
+++ b/src/core/classic/Classic.ts
@@ -72,6 +72,7 @@ export enum LineValue {
 }
 
 export type ClassicStates = {
+  type: "classic";
   corX: number;
   corY: number;
   ghostCorY: number;
@@ -570,6 +571,7 @@ export class Classic {
     );
 
     return {
+      type: "classic",
       corX: this.corX,
       corY: this.corY,
       ghostCorY: this.ghostCorY,

--- a/src/core/nemein/Nemein.ts
+++ b/src/core/nemein/Nemein.ts
@@ -76,6 +76,7 @@ export enum LineValue {
 }
 
 export type NemeinStates = {
+  type: "nemein";
   corX: number;
   corY: number;
   ghostCorY: number;
@@ -527,6 +528,7 @@ export class Nemein {
     logger.debug(`[Nemein] This tick's interval: ${this.gameInterval}ms`);
 
     return {
+      type: "nemein",
       corX: this.corX,
       corY: this.corY,
       ghostCorY: this.ghostCorY,


### PR DESCRIPTION
**TBS-146**

There are a few problems with the current WebSocket implementation such as:

- Unclear typings for the WebSocket data, which leads to mismatch data types under the same opcodes. For example, the `Ready` opcode sends a string as data on the client but sends the game states as data on the server. The server should send back a string confirming the game mode and send the game states under the game states opcode.

- There are some unnecessary checks in the `destroy()` method of the socket classes. `destroy()` is being called to close the connection immediately so there is no need to check if the socket is open. The server can also close the sockets with `terminate()` instead of `close()` because of the same reason. See [WebSocket.terminate() vs WebSocket.close() ](https://github.com/websockets/ws/issues/1596#issuecomment-504721417).

- The use of instanceof to determine the game type generates unnecessary overheads every time the server sends an updated state to the client. The game instance type can be updated to include a string specifying the game mode to speed up this check.

- The way we use `setTimeout` as an interval doesn’t differ from using `setInterval` anymore and therefore, it should be replaced with `setInterval`. This also helps reduce the amount of timer objects we create.

**TBS-147**

The game states should include a `type` property so that the client can distinguish the game type with only the state object, reducing the amount of checks the client has to do when rendering sprites.